### PR TITLE
Table improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ It is best to position the model more vertically to avoid tactile layer-to-layer
 
 `STL/Choc-Combined` and `STL/MX-Combined` contains files that you can use in any 3D-printing service like [JLCPCB](https://3d.jlcpcb.com/3d-printing/stereolithography) or [PCBWay](https://www.pcbway.com/rapid-prototyping/3d-printing/). You can download them directly using links below:
 
-| File          | Choc                           | MX                           |
-|:--------------|:-------------------------------|:-----------------------------|
-| Normal Part 1 | [Download][normal-part-1-choc] | [Download][normal-part-1-mx] |
-| Normal Part 2 | [Download][normal-part-2-choc] | [Download][normal-part-2-mx] |
-| Saddle Part 1 | [Download][saddle-part-1-choc] | [Download][saddle-part-1-mx] |
-| Saddle Part 2 | [Download][saddle-part-2-choc] | [Download][saddle-part-2-mx] |
+| File          | Choc                           | MX                           | Kinds                                                                        |
+|:--------------|:-------------------------------|:-----------------------------|------------------------------------------------------------------------------|
+| Normal Part 1 | [Download][normal-part-1-choc] | [Download][normal-part-1-mx] | - 6 × Normal Tilted<br/>- 3 × Normal                                         |
+| Normal Part 2 | [Download][normal-part-2-choc] | [Download][normal-part-2-mx] | - 4 × Normal Tilted<br/>- 3 × Thumb<br/>- 1 × Normal Homing<br/>- 1 × Normal |
+| Saddle Part 1 | [Download][saddle-part-1-choc] | [Download][saddle-part-1-mx] | - 6 × Saddle Tilted<br/>- 3 × Saddle                                         |
+| Saddle Part 2 | [Download][saddle-part-2-choc] | [Download][saddle-part-2-mx] | - 4 × Saddle Tilted<br/>- 4 × Saddle<br/>- 1 × Saddle Homing                 |
 
 
 [normal-part-1-choc]: ./STL/Choc-Combined/KLP_Lame_Normal-6xNormal_Tilted-3xNormal-Combined.7z
@@ -65,26 +65,6 @@ It is best to position the model more vertically to avoid tactile layer-to-layer
 [saddle-part-2-choc]: ./STL/Choc-Combined/KLP_Lame_Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z
 [saddle-part-2-mx]: ./STL/MX-Combined/KLP_Lame_MX-Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z
 
-
-
-**Normal Part 1**:
-- 6 × Normal Tilted
-- 3 × Normal
-
-**Normal Part 2**:
-- 4 × Normal Tilted
-- 3 × Thumb
-- 1 × Normal Homing
-- 1 × Normal
-
-**Saddle Part 1**:
-- 6 × Saddle Tilted
-- 3 × Saddle
-
-**Saddle Part 2**:
-- 4 × Saddle Tilted
-- 4 × Saddle
-- 1 × Saddle Homing
 
 > Warning! Lychee project files are deprecated and should be used only as example of making supports. Better to use the original STL files instead.
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,24 @@ It is best to position the model more vertically to avoid tactile layer-to-layer
 
 `STL/Choc-Combined` and `STL/MX-Combined` contains files that you can use in any 3D-printing service like [JLCPCB](https://3d.jlcpcb.com/3d-printing/stereolithography) or [PCBWay](https://www.pcbway.com/rapid-prototyping/3d-printing/). You can download them directly using links below:
 
-| File          | Choc                                                                                                         | MX                                                                                                            |
-| :------------ | :----------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
-| Normal Part 1 | [Download](./STL/Choc-Combined/KLP_Lame_Normal-6xNormal_Tilted-3xNormal-Combined.7z)                         | [Download](./STL/MX-Combined/KLP_Lame_MX-Normal-6xNormal_Tilted-3xNormal-Combined.7z)                         |
-| Normal Part 2 | [Download](./STL/Choc-Combined/KLP_Lame_Normal-4xNormal_Tilted-3xThumb-1xNormal_Homing-1xNormal-Combined.7z) | [Download](./STL/MX-Combined/KLP_Lame_MX-Normal-4xNormal_Tilted-3xThumb-1xNormal_Homing-1xNormal-Combined.7z) |
-| Saddle Part 1 | [Download](./STL/Choc-Combined/KLP_Lame_Saddle-6xSaddle_Tilted-3xSaddle-Combined.7z)                         | [Download](./STL/MX-Combined/KLP_Lame_MX-Saddle-6xSaddle_Tilted-3xSaddle-Combined.7z)                         |
-| Saddle Part 2 | [Download](./STL/Choc-Combined/KLP_Lame_Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z)         | [Download](./STL/MX-Combined/KLP_Lame_MX-Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z)         |
+| File          | Choc                           | MX                           |
+|:--------------|:-------------------------------|:-----------------------------|
+| Normal Part 1 | [Download][normal-part-1-choc] | [Download][normal-part-1-mx] |
+| Normal Part 2 | [Download][normal-part-2-choc] | [Download][normal-part-2-mx] |
+| Saddle Part 1 | [Download][saddle-part-1-choc] | [Download][saddle-part-1-mx] |
+| Saddle Part 2 | [Download][saddle-part-2-choc] | [Download][saddle-part-2-mx] |
+
+
+[normal-part-1-choc]: ./STL/Choc-Combined/KLP_Lame_Normal-6xNormal_Tilted-3xNormal-Combined.7z
+[normal-part-1-mx]: ./STL/MX-Combined/KLP_Lame_MX-Normal-6xNormal_Tilted-3xNormal-Combined.7z
+[normal-part-2-choc]: ./STL/Choc-Combined/KLP_Lame_Normal-4xNormal_Tilted-3xThumb-1xNormal_Homing-1xNormal-Combined.7z
+[normal-part-2-mx]: ./STL/MX-Combined/KLP_Lame_MX-Normal-4xNormal_Tilted-3xThumb-1xNormal_Homing-1xNormal-Combined.7z
+[saddle-part-1-choc]: ./STL/Choc-Combined/KLP_Lame_Saddle-6xSaddle_Tilted-3xSaddle-Combined.7z
+[saddle-part-1-mx]: ./STL/MX-Combined/KLP_Lame_MX-Saddle-6xSaddle_Tilted-3xSaddle-Combined.7z
+[saddle-part-2-choc]: ./STL/Choc-Combined/KLP_Lame_Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z
+[saddle-part-2-mx]: ./STL/MX-Combined/KLP_Lame_MX-Saddle-4xSaddle_Tilted-4xSaddle-1xSaddle_Homing-Combined.7z
+
+
 
 **Normal Part 1**:
 - 6 × Normal Tilted


### PR DESCRIPTION
Another couple of layout improvements:

- The table with printable files contains the kind of keycaps too. This should make it easier for people to read them

It will look like this

![image](https://github.com/user-attachments/assets/84ace156-5ff1-4d54-8ef1-5e7ce00cfead)

- Then markdown links have been changed to reference-style links. This will let you have the table fitting the screen, within 80 chars or the like.